### PR TITLE
function that handles file names with a `!` prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,17 +30,25 @@ function checkFile(file, cb) {
 	return true;
 }
 
-// creates new pipe for files from bundle
-function processBundleFile(file, bundleExt, bundleHandler) {
+//builds path for each line in file - handles `!` negated file paths
+function createPath (file, line) {
 	// get paths
 	var relative = path.relative(process.cwd(), file.path);
 	var dir = path.dirname(relative);
+	var filePath;
 
+	filePath = (line[0] === '!') ? '!' + path.join(dir, line.substr(1)) : path.join(dir, line);
+
+	return filePath;
+}
+
+// creates new pipe for files from bundle
+function processBundleFile(file, bundleExt, bundleHandler) {
 	// get bundle files
 	var lines = file.contents.toString().split('\n');
 	var resultFilePaths = [];
 	lines.forEach(function(line) {
-		resultFilePaths.push(path.join(dir, line));
+		resultFilePaths.push(createPath(file, line));
 	});
 
 	// find files and send to buffer
@@ -88,10 +96,10 @@ module.exports = {
 		return through2.obj(function(file, enc, cb) {
 			if (!checkFile(file, cb))
 				return;
-			
+
 			var ext = path.extname(file.path).toLowerCase();
 			var resultFileName = path.basename(file.path, ext);
-			
+
 			var bundleFiles = processBundleFile(file, ext, bundleHandler);
 			if (file.sourceMap)
 				bundleFiles = bundleFiles.pipe(sourcemaps.init());


### PR DESCRIPTION
I had an issue where if I had a source path I wanted to negate, the wrong path was being built. Using OSX El Capitan


example bundle file: 

```
../../.tmp/scripts/**/*.js
!../../.tmp/scripts/vendor/*.js
```

caused `resultFilePaths` to be 
```
[ '.tmp/scripts/**/*.js',
  'node_modules/someDir/.tmp/scripts/vendor/*.js',
  'node_modules/someDir' ]
```

This PR introduces a new function that checks if the line starts with a bang(`!`). If so, it builds the path as if the `!` was not present, and then prepends it again before returning. 


(I should explain that i was using this in a private node module that was being pulled into the current project)